### PR TITLE
fix: check if parent Nvim has unnest.nvim dir instead of --clean

### DIFF
--- a/lua/unnest/init.lua
+++ b/lua/unnest/init.lua
@@ -2,6 +2,47 @@ local M = {}
 
 local api = vim.api
 
+--- :UnnestEdit {cmd}
+---@param cmd vim.api.keyset.create_user_command.command_args
+function M.ex_edit(cmd)
+	vim.cmd.enew()
+	local child_chan = vim.fn.jobstart(vim.fn.expandcmd(cmd.args), {
+		term = true,
+		env = {
+			NVIM_UNNEST_NOWAIT = 1,
+		}
+	})
+	vim.w.unnest_chan = child_chan
+	local buf = api.nvim_get_current_buf()
+	api.nvim_create_autocmd('BufHidden', {
+		buffer = buf,
+		callback = function()
+			vim.fn.jobstop(child_chan)
+			vim.schedule(function()
+				api.nvim_buf_delete(buf, { force = true })
+			end)
+		end,
+	})
+	vim.cmd.startinsert()
+end
+
+---@param list string[]
+---@param path string
+---@return boolean
+M.list_contains_path = function(list, path)
+	---@param path string
+	---@return string
+	local function normalize_abspath(path)
+		return vim.fs.normalize(vim.fs.abspath(path))
+	end
+
+	return vim.list_contains(
+		vim.tbl_map(normalize_abspath, list),
+		normalize_abspath(path))
+end
+
+---@param winlayout vim.fn.winlayout.ret
+---@return string[]
 M.winlayout_to_cmds = function(winlayout)
 	local commands = {} ---@type string[]
 


### PR DESCRIPTION
Problem:
- Checkin --clean like the previous way means there is no way unnest.nvim users can reproduce bug related to this plugin with `nvim --clean -u repro.lua`

Solution:
- Check if parent Nvim has unnest.nvim dir instead of --clean