### PR TITLE
docs: misc

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -45,11 +45,17 @@ body:
   - type: textarea
     attributes:
       label: Steps To Reproduce
-      description: Steps to reproduce the behavior.
+      description: Steps to reproduce the behavior. You should use $NVIM_APPNAME for reproduce steps
       value: |
-        1. Clone the plugin `git clone https://github.com/brianhuster/unnest.nvim`
-        2. Open Nvim with minimal repro file `nvim --clean -u minimal_init.lua`
-        3. ...
+        1. export NVIM_APPNAME=nvim_unnest
+        2. nvim
+        3. Open config file for $NVIM_APPNAME=nvim_unnest
+        ```vim
+        :edit `=stdpath('config')..'/init.lua'`
+        ```
+        4. Write your minimal_config there and save with `:w ++p`
+        5. Restart Nvim
+        ... More steps here ...
     validations:
       required: true
 
@@ -63,7 +69,7 @@ body:
   - type: textarea
     attributes:
       label: Minimal config to reproduce
-      description: Minimal `init.lua` to reproduce this issue. Save as `minimal_init.lua` and run with `nvim -u minimal_init.lua`
+      description: Minimal `init.lua` to reproduce this issue. Save to $XDG_CONFIG_HOME/$NVIM_APPNAME/init.lua
       value: |
         vim.cmd.set "rtp+=/path/to/unnest.nvim"
 

--- a/doc/unnest.txt
+++ b/doc/unnest.txt
@@ -26,9 +26,9 @@ NOTE: there are some other plugins that do similar thing, like
 |unnest.nvim| should works automatically. There is no configuration needed.
 
 When you run a command in terminal buffer that would open a Nvim instance, the
-parent Nvim instance will open a new tab with the same layout as the child
+parent Nvim instance will open a new |tabpage| with the same layout as the child
 Nvim instance. The child Nvim instance will be kept until you close that new
-tab. This is usefull when you use commands like `git commit`, `git mergetool`,
+|tabpage|. This is usefull when you use commands like `git commit`, `git mergetool`,
 etc
 
 NOTE: this plugin won't work if you lazy-load it. And actually you shouldn't
@@ -38,15 +38,15 @@ need lazy-loading for this plugin because it has very small startup time.
 COMMANDS ~
 
 *:UnnestEdit* {cmd}
-    Run {cmd} in a Nvim terminal buffer in the current window. All
+    Run {cmd} in a Nvim terminal buffer in the current |window|. All
     |cmdline-special| characters in {cmd} are expanded. If it opens a Nvim
     instance with a file path, the file will be opened in the parent Nvim
     instance, and the child Nvim instance will be closed right away.
 
     As you can see, the behavior is a bit different from the default behavior,
-    instead of opening a new tab, this command just opens file in the current
-    window, and the child Nvim instance is not kept. This is useful when you
-    want to use another terminal file explorer with Nvim.
+    instead of opening a new |tabpage|, this command just opens file in the
+    current |window|, and the child Nvim instance is not kept. This is useful
+    when you want to use another terminal file explorer with Nvim.
 
     Some example usages:
 


### PR DESCRIPTION
Problem:
- Reproduce steps like `nvim --clean -u something.lua` doesn't work with this plugin because it doesn't change how the nested Nvim is started.
- The document uses the term `tab` instead of `tabpage`, which seems incorrect

Solution:
- Use `tabpage` instead of `tab` in the document
- Update bug report template