### PR TITLE
fix: lint with LuaLS doesn't work if Nvim is a sandboxed package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,7 @@ test: .venv/touchfile
 	$(PYTEST) test
 
 lint:
-	VIMRUNTIME=$$(nvim --clean --headless +"lua io.stdout:write(vim.env.VIMRUNTIME)" +q) \
-	lua-language-server --check=. --configpath=.nvim.lua
+	nvim --clean -l scripts/luals.lua
 
 format:
 	stylua .

--- a/scripts/luals.lua
+++ b/scripts/luals.lua
@@ -1,0 +1,24 @@
+--- @brief Must run lua-language-server inside a Nvim instance, because
+--- $VIMRUNTIME is only available there. Also some packages like `appimage` or
+--- `snap` even remove $VIMRUNTIME directory after the Nvim session is closed,
+--- so command like `VIMRUNTIME = $(nvim --clean --headless +"lua
+--- io.stdout:write(vim.env.VIMRUNTIME)" +q)` won't work with them.
+
+---@param err string?
+---@param out string?
+local function handle_output(err, out)
+	if err then
+		io.stderr:write(err)
+	end
+	if out then
+		io.stdout:write(out)
+	end
+end
+
+vim.system({ "lua-language-server", "--check=.", "--configpath=.nvim.lua" }, {
+	text = true,
+	stdout = handle_output,
+	stderr = handle_output,
+}, function(out)
+	os.exit(out.code)
+end):wait()


### PR DESCRIPTION
Problem:
- Some packages like `appimage` or `snap` will remove $VIMRUNTIME after the Nvim session is closed, so command like `VIMRUNTIME = $(nvim --clean --headless +"lua io.stdout:write(vim.env.VIMRUNTIME)" +q)` won't work with them.

Solution:
- Must run `lua-language-server` inside a Nvim instance, via `nvim --clean -l {scriptname}`