### PR TITLE
test: unset $SHELL and reduce wait time

### DIFF
--- a/scripts/vendor/busted.lua
+++ b/scripts/vendor/busted.lua
@@ -223,9 +223,6 @@ M.pending = function(desc)
 	print(pending, "||", table.concat(curr_stack, " "))
 end
 
----@class expectation
-local expectation = {}
-
 local function matcher(fun)
 	return function(self, ...)
 		fun(self, ...)
@@ -233,6 +230,14 @@ local function matcher(fun)
 		return self
 	end
 end
+
+---@class expectation
+local expectation = {
+	Not = function(self)
+		self._not = not self._not
+		return self
+	end,
+}
 
 --- Reverse the expectation of the next matcher only. Many :Not() can be
 --- chained, which will reversed the previous :Not(). For example:

--- a/spec/plugin_spec.lua
+++ b/spec/plugin_spec.lua
@@ -30,6 +30,9 @@ describe("test plugin", function()
 				-- must unset $NVIM, otherwise it will hopelessly try to
 				-- control the Nvim that run busted
 				NVIM = "",
+				-- Unset $SHELL to make tests use POSIX shell (sh) on POSIX
+				-- systems. This doesn't affect Windows though.
+				SHELL = "",
 			},
 		}))
 	end)
@@ -41,7 +44,7 @@ describe("test plugin", function()
 	it("Test command :UnnestEdit", function()
 		local win = nvim.nvim_get_current_win()
 		nvim.nvim_command("UnnestEdit nvim Xtest/tmp/test_command.txt")
-		vim.wait(500)
+		vim.wait(200)
 
 		-- job must have been closed
 		local job = nvim.nvim_win_get_var(win, "unnest_chan")
@@ -62,7 +65,7 @@ describe("test plugin", function()
 		local tab = nvim.nvim_get_current_tabpage()
 
 		nvim.nvim_command(cmd)
-		vim.wait(500)
+		vim.wait(200)
 
 		-- Must be in a new tab
 		expect(nvim.nvim_get_current_tabpage()):Not():same(tab)


### PR DESCRIPTION
Problem:

- Some users have a shell config that have long startup time. This can make tests fail because they wait for the shell to start. Actually this problem doesn't exist in any of the tests yet, but in the future we could add a test that need to interact with terminal buffer directly
- 500ms is probably too long

Solution:

- Unset $SHELL to make tests use POSIX shell (sh) on POSIX systems. This doesn't affect Windows though.
- Try reducing wait time from 500ms to 200ms